### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <commons-codec>1.3</commons-codec>
         <commons-fileupload>1.2.2</commons-fileupload>
         <commons-io>2.0.1</commons-io>
-        <commons-collections>3.2.1</commons-collections>
+        <commons-collections>3.2.2</commons-collections>
         <commons-lang>2.4</commons-lang>
         <commons-validator>1.3.1</commons-validator>
         <commons-dbcp>1.4</commons-dbcp>


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/