### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Example](http://encuestame.org/logos/horizontal/enuestame_horizontal_small_alpha.png)
 
-##Encuestame Open Source Social Survey
+## Encuestame Open Source Social Survey
 
 *Current version in Development https://github.com/encuestame/encuestame/tree/2.0-beta
 

--- a/enme-installer/README.md
+++ b/enme-installer/README.md
@@ -1,6 +1,6 @@
 ![Example](http://encuestame.org/logos/horizontal/enuestame_horizontal_small_alpha.png)
 
-##Encuestame Installer
+## Encuestame Installer
 
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/encuestame/encuestame?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/enme-js/src/main/resources/src/me/README.md
+++ b/enme-js/src/main/resources/src/me/README.md
@@ -9,7 +9,7 @@ Encuestame UI is based in Dojo Widgets, we use [Intern](http://theintern.io/) to
 
 ### Sponsors
 
-#![BrowserStack](http://encuestame.org/images/sponsors/browserstack/browserstack.jpg)
+# ![BrowserStack](http://encuestame.org/images/sponsors/browserstack/browserstack.jpg)
 
 ### Setup
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
